### PR TITLE
Replace all drive references with chassis references

### DIFF
--- a/include/ARMS/chassis.h
+++ b/include/ARMS/chassis.h
@@ -7,34 +7,34 @@
 namespace chassis {
 
 /**
- * Set the brake mode for all drive motors
+ * Set the brake mode for all chassis motors
  */
 void setBrakeMode(okapi::AbstractMotor::brakeMode b);
 
 /**
- * Reset the internal motor encoders for all drive motors
+ * Reset the internal motor encoders for all chassis motors
  */
 void reset();
 
 /**
- * Get the average position between the sides of the drive
+ * Get the average position between the sides of the chassis
  */
-int drivePos();
+int position();
 
 /**
- * Get a boolean that is true if the drive motors are in motion
+ * Get a boolean that is true if the chassis motors are in motion
  */
 bool isDriving();
 
 /**
- * Delay the program until the drive motors come to rest
+ * Delay the program until the chassis motors come to rest
  */
 void waitUntilSettled();
 
 /**
- * Begin an asycronous drive movement
+ * Begin an asycronous chassis movement
  */
-void driveAsync(double sp, int max = 100);
+void moveAsync(double sp, int max = 100);
 
 /**
  * Begin an asycronous turn movement
@@ -42,9 +42,9 @@ void driveAsync(double sp, int max = 100);
 void turnAsync(double sp, int max = 100);
 
 /**
- * Perform a drive movement and wait until settled
+ * Perform a chassis movement and wait until settled
  */
-void drive(double sp, int max = 100);
+void move(double sp, int max = 100);
 
 /**
  * Perform a turn movement and wait until settled
@@ -54,17 +54,17 @@ void turn(double sp, int max = 100);
 /**
  * Move a distance at a set voltage with no PID
  */
-void fastDrive(double sp, int max = 100);
+void fast(double sp, int max = 100);
 
 /**
  * Move for a duration at a set voltage with no PID
  */
-void timeDrive(int t, int left = 100, int right = 0);
+void time(int t, int left_speed = 100, int right_speed = 0);
 
 /**
  * Move for a duration at a set velocity using internal PID
  */
-void velocityDrive(int t, int max = 100);
+void velocity(int t, int max = 100);
 
 /**
  * Move the robot in an arc with a set length, radius, and speed
@@ -107,17 +107,16 @@ void tank(int left, int right);
 void arcade(int vertical, int horizontal);
 
 /**
- * initialize the drive
+ * initialize the chassis
  */
-void initDrive(std::initializer_list<okapi::Motor> leftMotors = {LEFT_MOTORS},
-               std::initializer_list<okapi::Motor> rightMotors = {RIGHT_MOTORS},
-               int gearset = GEARSET, int distance_constant = DISTANCE_CONSTANT,
-               double degree_constant = DEGREE_CONSTANT,
-               int accel_step = ACCEL_STEP, int deccel_step = DECCEL_STEP,
-               int arc_step = ARC_STEP, double driveKP = DRIVE_KP,
-               double driveKD = DRIVE_KD, double turnKP = TURN_KP,
-               double turnKD = TURN_KD, double arcKP = ARC_KP,
-               int imuPort = IMU_PORT);
+void init(std::initializer_list<okapi::Motor> leftMotors = {LEFT_MOTORS},
+          std::initializer_list<okapi::Motor> rightMotors = {RIGHT_MOTORS},
+          int gearset = GEARSET, int distance_constant = DISTANCE_CONSTANT,
+          double degree_constant = DEGREE_CONSTANT, int accel_step = ACCEL_STEP,
+          int deccel_step = DECCEL_STEP, int arc_step = ARC_STEP,
+          double linearKP = LINEAR_KP, double linearKD = LINEAR_KD,
+          double turnKP = TURN_KP, double turnKD = TURN_KD,
+          double arcKP = ARC_KP, int imuPort = IMU_PORT);
 
 } // namespace chassis
 

--- a/include/ARMS/config.h
+++ b/include/ARMS/config.h
@@ -18,8 +18,8 @@ namespace chassis {
 #define ARC_STEP 2      // acceleration for arcs
 
 // pid constants
-#define DRIVE_KP .3
-#define DRIVE_KD .5
+#define LINEAR_KP .3
+#define LINEAR_KD .5
 #define TURN_KP .8
 #define TURN_KD 3
 #define ARC_KP .05

--- a/src/ARMS/chassis.cpp
+++ b/src/ARMS/chassis.cpp
@@ -9,7 +9,7 @@ namespace chassis {
 // imu
 std::shared_ptr<Imu> imu;
 
-// drive motors
+// chassis motors
 std::shared_ptr<okapi::MotorGroup> leftMotors;
 std::shared_ptr<okapi::MotorGroup> rightMotors;
 
@@ -23,37 +23,37 @@ int deccel_step; // 200 = no slew
 int arc_step;    // acceleration for arcs
 
 // pid constants
-double driveKP;
-double driveKD;
+double linearKP;
+double linearKD;
 double turnKP;
 double turnKD;
 double arcKP;
 
 /**************************************************/
 // edit below with caution!!!
-static int driveMode = 0;
-static int driveTarget = 0;
+static int chassisMode = 0;
+static int linearTarget = 0;
 static int turnTarget = 0;
 static int maxSpeed = 100;
 
 /**************************************************/
 // basic control
-void left_drive(int vel) {
+void left(int vel) {
 	vel *= 120;
 	leftMotors->moveVoltage(vel);
 }
 
-void right_drive(int vel) {
+void right(int vel) {
 	vel *= 120;
 	rightMotors->moveVoltage(vel);
 }
 
-void left_drive_vel(int vel) {
+void left_vel(int vel) {
 	vel *= (double)leftMotors->getGearing() / 100;
 	leftMotors->moveVelocity(vel);
 }
 
-void right_drive_vel(int vel) {
+void right_vel(int vel) {
 	vel *= (double)leftMotors->getGearing() / 100;
 	rightMotors->moveVelocity(vel);
 }
@@ -61,8 +61,8 @@ void right_drive_vel(int vel) {
 void setBrakeMode(okapi::AbstractMotor::brakeMode b) {
 	leftMotors->setBrakeMode(b);
 	rightMotors->setBrakeMode(b);
-	left_drive_vel(0);
-	right_drive_vel(0);
+	left_vel(0);
+	right_vel(0);
 }
 
 void reset() {
@@ -70,7 +70,7 @@ void reset() {
 	rightMotors->tarePosition();
 }
 
-int drivePos() {
+int position() {
 	return (rightMotors->getPosition() + leftMotors->getPosition()) / 2;
 }
 
@@ -81,7 +81,7 @@ int slew(int speed) {
 	int step;
 
 	if (abs(lastSpeed) < abs(speed))
-		if (driveMode == 0)
+		if (chassisMode == 0)
 			step = arc_step;
 		else
 			step = accel_step;
@@ -100,17 +100,17 @@ int slew(int speed) {
 }
 
 /**************************************************/
-// drive settling
+// chassis settling
 bool isDriving() {
 	static int count = 0;
 	static int last = 0;
 	static int lastTarget = 0;
 
-	int curr = drivePos();
+	int curr = position();
 
 	int target = turnTarget;
-	if (driveMode == 1)
-		target = driveTarget;
+	if (chassisMode == 1)
+		target = linearTarget;
 
 	if (abs(last - curr) < 3)
 		count++;
@@ -137,12 +137,12 @@ void waitUntilSettled() {
 
 /**************************************************/
 // autonomous functions
-void driveAsync(double sp, int max) {
+void moveAsync(double sp, int max) {
 	sp *= distance_constant;
 	reset();
 	maxSpeed = max;
-	driveTarget = sp;
-	driveMode = 1;
+	linearTarget = sp;
+	chassisMode = 1;
 }
 
 void turnAsync(double sp, int max) {
@@ -150,11 +150,11 @@ void turnAsync(double sp, int max) {
 	reset();
 	maxSpeed = max;
 	turnTarget = sp;
-	driveMode = -1;
+	chassisMode = -1;
 }
 
-void drive(double sp, int max) {
-	driveAsync(sp, max);
+void move(double sp, int max) {
+	moveAsync(sp, max);
 	delay(450);
 	waitUntilSettled();
 }
@@ -165,39 +165,39 @@ void turn(double sp, int max) {
 	waitUntilSettled();
 }
 
-void fastDrive(double sp, int max) {
+void fast(double sp, int max) {
 	if (sp < 0)
 		max = -max;
 	reset();
 	lastSpeed = max;
-	driveMode = 0;
-	left_drive(max);
-	right_drive(max);
+	chassisMode = 0;
+	left(max);
+	right(max);
 
 	if (sp > 0)
-		while (drivePos() < sp * distance_constant)
+		while (position() < sp * distance_constant)
 			delay(20);
 	else
-		while (drivePos() > sp * distance_constant)
+		while (position() > sp * distance_constant)
 			delay(20);
 }
 
-void timeDrive(int t, int left, int right) {
-	left_drive(left);
-	right_drive(right == 0 ? left : right);
+void time(int t, int left_speed, int right_speed) {
+	left(left_speed);
+	right(right_speed == 0 ? left_speed : right_speed);
 	delay(t);
 }
 
-void velocityDrive(int t, int max) {
-	left_drive_vel(max);
-	right_drive_vel(max);
+void velocity(int t, int max) {
+	left_vel(max);
+	right_vel(max);
 	delay(t);
 }
 
 void arc(bool mirror, int arc_length, double rad, int max, int type) {
 	reset();
 	int time_step = 0;
-	driveMode = 0;
+	chassisMode = 0;
 	bool reversed = false;
 
 	// reverse the movement if the length is negative
@@ -208,8 +208,8 @@ void arc(bool mirror, int arc_length, double rad, int max, int type) {
 
 	// fix jerk bug between velocity movements
 	if (type < 2) {
-		left_drive_vel(0);
-		right_drive_vel(0);
+		left_vel(0);
+		right_vel(0);
 		delay(10);
 	}
 
@@ -246,9 +246,9 @@ void arc(bool mirror, int arc_length, double rad, int max, int type) {
 		else if (type == 3)
 			scaled_speed *= (1 - (double)time_step / arc_length);
 
-		// assign drive motor speeds
-		left_drive_vel(mirror ? speed : scaled_speed);
-		right_drive_vel(mirror ? scaled_speed : speed);
+		// assign chassis motor speeds
+		left_vel(mirror ? speed : scaled_speed);
+		right_vel(mirror ? scaled_speed : speed);
 
 		// increment time step
 		time_step += 10;
@@ -256,8 +256,8 @@ void arc(bool mirror, int arc_length, double rad, int max, int type) {
 	}
 
 	if (type != 1 && type != 2) {
-		left_drive_vel(0);
-		right_drive_vel(0);
+		left_vel(0);
+		right_vel(0);
 	}
 }
 
@@ -275,7 +275,7 @@ void scurve(bool mirror, int arc1, int mid, int arc2, int max) {
 	arc(mirror, arc1, 1, max, 1);
 
 	// middle movement
-	velocityDrive(mid, max);
+	velocity(mid, max);
 
 	// final arc
 	arc(!mirror, arc2, 1, max, 2);
@@ -348,7 +348,7 @@ int odomTask() {
 		delay(10);
 	}
 }
-int driveTask() {
+int chassisTask() {
 	int prevError = 0;
 	double kp;
 	double kd;
@@ -357,11 +357,11 @@ int driveTask() {
 	while (1) {
 		delay(20);
 
-		if (driveMode == 1) {
-			sp = driveTarget;
-			kp = driveKP;
-			kd = driveKD;
-		} else if (driveMode == -1) {
+		if (chassisMode == 1) {
+			sp = linearTarget;
+			kp = linearKP;
+			kd = linearKD;
+		} else if (chassisMode == -1) {
 			sp = turnTarget;
 			kp = turnKP;
 			kd = turnKD;
@@ -371,7 +371,7 @@ int driveTask() {
 
 		// read sensors
 		int sv =
-		    (rightMotors->getPosition() + leftMotors->getPosition() * driveMode) /
+		    (rightMotors->getPosition() + leftMotors->getPosition() * chassisMode) /
 		    2;
 
 		// speed
@@ -389,21 +389,21 @@ int driveTask() {
 		speed = slew(speed); // slew
 
 		// set motors
-		left_drive(speed * driveMode);
-		right_drive(speed);
+		left(speed * chassisMode);
+		right(speed);
 	}
 }
 
 void startTasks() {
-	Task drive_task(driveTask);
+	Task chassis_task(chassisTask);
 	Task odom_task(odomTask);
 }
 
-void initDrive(std::initializer_list<okapi::Motor> leftMotors,
-               std::initializer_list<okapi::Motor> rightMotors, int gearset,
-               int distance_constant, double degree_constant, int accel_step,
-               int deccel_step, int arc_step, double driveKP, double driveKD,
-               double turnKP, double turnKD, double arcKP, int imuPort) {
+void init(std::initializer_list<okapi::Motor> leftMotors,
+          std::initializer_list<okapi::Motor> rightMotors, int gearset,
+          int distance_constant, double degree_constant, int accel_step,
+          int deccel_step, int arc_step, double linearKP, double linearKD,
+          double turnKP, double turnKD, double arcKP, int imuPort) {
 
 	// assign constants
 	chassis::distance_constant = distance_constant;
@@ -411,13 +411,13 @@ void initDrive(std::initializer_list<okapi::Motor> leftMotors,
 	chassis::accel_step = accel_step;
 	chassis::deccel_step = deccel_step;
 	chassis::arc_step = arc_step;
-	chassis::driveKP = driveKP;
-	chassis::driveKD = driveKD;
+	chassis::linearKP = linearKP;
+	chassis::linearKD = linearKD;
 	chassis::turnKP = turnKP;
 	chassis::turnKD = turnKD;
 	chassis::arcKP = arcKP;
 
-	// configure drive motors
+	// configure chassis motors
 	chassis::leftMotors = std::make_shared<okapi::MotorGroup>(leftMotors);
 	chassis::rightMotors = std::make_shared<okapi::MotorGroup>(rightMotors);
 	chassis::leftMotors->setGearing((okapi::AbstractMotor::gearset)gearset);
@@ -439,16 +439,16 @@ void initDrive(std::initializer_list<okapi::Motor> leftMotors,
 
 /**************************************************/
 // operator control
-void tank(int left, int right) {
-	driveMode = 0; // turns off autonomous tasks
-	left_drive(left);
-	right_drive(right);
+void tank(int left_speed, int right_speed) {
+	chassisMode = 0; // turns off autonomous tasks
+	left(left_speed);
+	right(right_speed);
 }
 
 void arcade(int vertical, int horizontal) {
-	driveMode = 0; // turns off autonomous task
-	left_drive(vertical + horizontal);
-	right_drive(vertical - horizontal);
+	chassisMode = 0; // turns off autonomous task
+	left(vertical + horizontal);
+	right(vertical - horizontal);
 }
 
 } // namespace chassis

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,7 +4,7 @@
 pros::Controller master(CONTROLLER_MASTER);
 
 void initialize() {
-	chassis::initDrive();
+	chassis::init();
 	selector::init();
 }
 


### PR DESCRIPTION
Several of the functions inside of the chassis subsystem have references to "drive" which is an obsolete term. We want to change it to match the other subsystems. For example, we want to use `chassis:init()` instead of `driveInit()` and `chassis::move(5)` instead of `drive(5)`.