### PR TITLE
T954 drift correction

### DIFF
--- a/include/ARMS/chassis.h
+++ b/include/ARMS/chassis.h
@@ -114,9 +114,10 @@ void init(std::initializer_list<okapi::Motor> leftMotors = {LEFT_MOTORS},
           int gearset = GEARSET, int distance_constant = DISTANCE_CONSTANT,
           double degree_constant = DEGREE_CONSTANT, int accel_step = ACCEL_STEP,
           int deccel_step = DECCEL_STEP, int arc_step = ARC_STEP,
-          double linearKP = LINEAR_KP, double linearKD = LINEAR_KD,
-          double turnKP = TURN_KP, double turnKD = TURN_KD,
-          double arcKP = ARC_KP, int imuPort = IMU_PORT,
+          int min_speed = MIN_SPEED, double linearKP = LINEAR_KP,
+          double linearKD = LINEAR_KD, double turnKP = TURN_KP,
+          double turnKD = TURN_KD, double arcKP = ARC_KP,
+          int imuPort = IMU_PORT,
           std::tuple<int, int, int, int> encoderPorts = {ENCODER_PORTS});
 
 } // namespace chassis

--- a/include/ARMS/chassis.h
+++ b/include/ARMS/chassis.h
@@ -116,7 +116,7 @@ void init(std::initializer_list<okapi::Motor> leftMotors = {LEFT_MOTORS},
           int deccel_step = DECCEL_STEP, int arc_step = ARC_STEP,
           int min_speed = MIN_SPEED, double linearKP = LINEAR_KP,
           double linearKD = LINEAR_KD, double turnKP = TURN_KP,
-          double turnKD = TURN_KD, double arcKP = ARC_KP,
+          double turnKD = TURN_KD, double arcKP = ARC_KP, double difKP = DIF_KP,
           int imuPort = IMU_PORT,
           std::tuple<int, int, int, int> encoderPorts = {ENCODER_PORTS});
 

--- a/include/ARMS/config.h
+++ b/include/ARMS/config.h
@@ -16,6 +16,7 @@ namespace chassis {
 #define ACCEL_STEP 8    // smaller number = more slew
 #define DECCEL_STEP 200 // 200 = no slew
 #define ARC_STEP 2      // acceleration for arcs
+#define MIN_SPEED 15
 
 // pid constants
 #define LINEAR_KP .3

--- a/include/ARMS/config.h
+++ b/include/ARMS/config.h
@@ -23,6 +23,7 @@ namespace chassis {
 #define TURN_KP .8
 #define TURN_KD 3
 #define ARC_KP .05
+#define DIF_KP .5
 
 // sensors
 #define IMU_PORT 0                       // port 0 for disabled

--- a/src/ARMS/chassis.cpp
+++ b/src/ARMS/chassis.cpp
@@ -30,6 +30,7 @@ double degree_constant; // ticks per degree
 int accel_step;  // smaller number = more slew
 int deccel_step; // 200 = no slew
 int arc_step;    // acceleration for arcs
+int min_speed;
 
 // pid constants
 double linearKP;
@@ -110,9 +111,6 @@ int slew(int speed) {
 	else
 		step = deccel_step;
 
-	// modify the step to pull harder at the bottom
-	step = pow(.18, step) + 1;
-
 	if (speed > lastSpeed + step)
 		lastSpeed += step;
 	else if (speed < lastSpeed - step)
@@ -121,7 +119,8 @@ int slew(int speed) {
 		lastSpeed = speed;
 	}
 
-	return lastSpeed;
+	return abs(lastSpeed) < min_speed && step == accel_step ? min_speed
+	                                                        : lastSpeed;
 }
 
 /**************************************************/
@@ -427,9 +426,9 @@ void startTasks() {
 void init(std::initializer_list<okapi::Motor> leftMotors,
           std::initializer_list<okapi::Motor> rightMotors, int gearset,
           int distance_constant, double degree_constant, int accel_step,
-          int deccel_step, int arc_step, double linearKP, double linearKD,
-          double turnKP, double turnKD, double arcKP, int imuPort,
-          std::tuple<int, int, int, int> encoderPorts) {
+          int deccel_step, int arc_step, int min_speed, double linearKP,
+          double linearKD, double turnKP, double turnKD, double arcKP,
+          int imuPort, std::tuple<int, int, int, int> encoderPorts) {
 
 	// assign constants
 	chassis::distance_constant = distance_constant;
@@ -437,6 +436,7 @@ void init(std::initializer_list<okapi::Motor> leftMotors,
 	chassis::accel_step = accel_step;
 	chassis::deccel_step = deccel_step;
 	chassis::arc_step = arc_step;
+	chassis::min_speed = min_speed;
 	chassis::linearKP = linearKP;
 	chassis::linearKD = linearKD;
 	chassis::turnKP = turnKP;

--- a/src/ARMS/chassis.cpp
+++ b/src/ARMS/chassis.cpp
@@ -75,6 +75,9 @@ void setBrakeMode(okapi::AbstractMotor::brakeMode b) {
 }
 
 void reset() {
+	left_vel(0);
+	right_vel(0);
+	delay(10);
 	leftMotors->tarePosition();
 	rightMotors->tarePosition();
 }
@@ -106,6 +109,9 @@ int slew(int speed) {
 			step = accel_step;
 	else
 		step = deccel_step;
+
+	// modify the step to pull harder at the bottom
+	step = pow(.18, step) + 1;
 
 	if (speed > lastSpeed + step)
 		lastSpeed += step;
@@ -406,8 +412,8 @@ int chassisTask() {
 		speed = slew(speed); // slew
 
 		// set motors
-		left(speed * mode);
-		right(speed);
+		left_vel(speed * mode);
+		right_vel(speed);
 	}
 }
 


### PR DESCRIPTION
- PID is now using velocity instead of voltage. This is slower, but less prone to drifting.
- Slew rate now has a minimum speed value during acceleration to help get the robot moving.
- A differential P controller has been added between each drive side to actively correct for drift. This is only really accurate when using external quad encoders mounted directly on wheel axles.