### PR TITLE
T855 imu turns

### DIFF
--- a/include/ARMS/chassis.h
+++ b/include/ARMS/chassis.h
@@ -143,7 +143,6 @@ void init(std::initializer_list<okapi::Motor> leftMotors = {LEFT_MOTORS},
           double linearKP = LINEAR_KP, double linearKD = LINEAR_KD,
           double turnKP = TURN_KP, double turnKD = TURN_KD,
           double arcKP = ARC_KP, double difKP = DIF_KP, int imuPort = IMU_PORT,
-          int imuPort = IMU_PORT,
           std::tuple<int, int, int> encoderPorts = {ENCODER_PORTS},
           int expanderPort = EXPANDER_PORT);
 

--- a/include/ARMS/chassis.h
+++ b/include/ARMS/chassis.h
@@ -19,7 +19,7 @@ void reset();
 /**
  * Get the average position between the sides of the chassis
  */
-double position(bool yDirection = false);
+double position(bool yDirection = false, bool forceEncoder = false);
 
 /**
  * Get a boolean that is true if the chassis motors are in motion
@@ -140,9 +140,9 @@ void init(std::initializer_list<okapi::Motor> leftMotors = {LEFT_MOTORS},
           int gearset = GEARSET, double distance_constant = DISTANCE_CONSTANT,
           double degree_constant = DEGREE_CONSTANT,
           double accel_step = ACCEL_STEP, double arc_step = ARC_STEP,
-          int min_speed = MIN_SPEED, double linearKP = LINEAR_KP,
-          double linearKD = LINEAR_KD, double turnKP = TURN_KP,
-          double turnKD = TURN_KD, double arcKP = ARC_KP, double difKP = DIF_KP,
+          double linearKP = LINEAR_KP, double linearKD = LINEAR_KD,
+          double turnKP = TURN_KP, double turnKD = TURN_KD,
+          double arcKP = ARC_KP, double difKP = DIF_KP, int imuPort = IMU_PORT,
           int imuPort = IMU_PORT,
           std::tuple<int, int, int> encoderPorts = {ENCODER_PORTS},
           int expanderPort = EXPANDER_PORT);

--- a/include/ARMS/chassis.h
+++ b/include/ARMS/chassis.h
@@ -42,6 +42,11 @@ void moveAsync(double sp, int max = 100);
 void turnAsync(double sp, int max = 100);
 
 /**
+ * Begin an asycronous absolute turn movement (only works with IMU)
+ */
+void turnAbsoluteAsync(double sp, int max = 100);
+
+/**
  * Begin an asycronous holonomic chassis movement
  */
 void moveAsync(double distance, double angle, int max = 100);
@@ -55,6 +60,12 @@ void move(double sp, int max = 100);
  * Perform a turn movement and wait until settled
  */
 void turn(double sp, int max = 100);
+
+/**
+ * Perform an absolute turn movement and wait until settled (only works with
+ * IMU)
+ */
+void turnAbsolute(double sp, int max = 100);
 
 /**
  * Perform a holonomic movement and wait until settled

--- a/include/ARMS/config.h
+++ b/include/ARMS/config.h
@@ -15,7 +15,6 @@ namespace chassis {
 // slew control (autonomous only)
 #define ACCEL_STEP 8 // smaller number = more slew
 #define ARC_STEP 2   // acceleration for arcs
-#define MIN_SPEED 15
 
 // pid constants
 #define LINEAR_KP .3

--- a/src/ARMS/chassis.cpp
+++ b/src/ARMS/chassis.cpp
@@ -13,7 +13,6 @@ namespace chassis {
 
 // imu
 std::shared_ptr<Imu> imu;
-int imuPort;
 
 // chassis motors
 std::shared_ptr<okapi::MotorGroup> leftMotors;
@@ -222,7 +221,7 @@ void moveAsync(double sp, int max) {
 void turnAsync(double sp, int max) {
 	mode = ANGULAR;
 
-	if (imuPort != 0)
+	if (imu)
 		sp += position();
 	else
 		sp *= degree_constant;
@@ -588,7 +587,6 @@ void init(std::initializer_list<okapi::Motor> leftMotors,
 	chassis::turnKD = turnKD;
 	chassis::arcKP = arcKP;
 	chassis::difKP = difKP;
-	chassis::imuPort = imuPort;
 
 	// configure chassis motors
 	chassis::leftMotors = std::make_shared<okapi::MotorGroup>(leftMotors);

--- a/src/ARMS/chassis.cpp
+++ b/src/ARMS/chassis.cpp
@@ -260,6 +260,12 @@ void turn(double sp, int max) {
 	waitUntilSettled();
 }
 
+void turnAbsolute(double sp, int max) {
+	turnAbsoluteAsync(sp, max);
+	delay(450);
+	waitUntilSettled();
+}
+
 void moveHolo(double distance, double angle, int max) {
 	moveHoloAsync(distance, angle, max);
 	delay(450);


### PR DESCRIPTION
Hopefully I did this correctly. Added a variable so that the IMU port can be tracked within the greenhat namespace. When there is an IMU, it is used by the turn function to do a relative turn. There is also a new function turnAbsolute which calls the turnRelative function but only works with IMU. The values in degrees outputted by the IMU are scaled by the degree constant so that the PID constants make sense for both turning methods.