### PR TITLE
Switch all chassis math to use doubles

### DIFF
--- a/include/ARMS/chassis.h
+++ b/include/ARMS/chassis.h
@@ -19,7 +19,7 @@ void reset();
 /**
  * Get the average position between the sides of the chassis
  */
-int position(bool yDirection = false);
+double position(bool yDirection = false);
 
 /**
  * Get a boolean that is true if the chassis motors are in motion
@@ -126,9 +126,9 @@ void holonomic(int x, int y, int z);
  */
 void init(std::initializer_list<okapi::Motor> leftMotors = {LEFT_MOTORS},
           std::initializer_list<okapi::Motor> rightMotors = {RIGHT_MOTORS},
-          int gearset = GEARSET, int distance_constant = DISTANCE_CONSTANT,
-          double degree_constant = DEGREE_CONSTANT, int accel_step = ACCEL_STEP,
-          int deccel_step = DECCEL_STEP, int arc_step = ARC_STEP,
+          int gearset = GEARSET, double distance_constant = DISTANCE_CONSTANT,
+          double degree_constant = DEGREE_CONSTANT,
+          double accel_step = ACCEL_STEP, double arc_step = ARC_STEP,
           int min_speed = MIN_SPEED, double linearKP = LINEAR_KP,
           double linearKD = LINEAR_KD, double turnKP = TURN_KP,
           double turnKD = TURN_KD, double arcKP = ARC_KP, double difKP = DIF_KP,

--- a/include/ARMS/config.h
+++ b/include/ARMS/config.h
@@ -13,9 +13,8 @@ namespace chassis {
 #define DEGREE_CONSTANT 2.3   // ticks per degree
 
 // slew control (autonomous only)
-#define ACCEL_STEP 8    // smaller number = more slew
-#define DECCEL_STEP 200 // 200 = no slew
-#define ARC_STEP 2      // acceleration for arcs
+#define ACCEL_STEP 8 // smaller number = more slew
+#define ARC_STEP 2   // acceleration for arcs
 #define MIN_SPEED 15
 
 // pid constants


### PR DESCRIPTION
To prevent a loss of precision, all chassis math uses doubles. This prevents truncated values and weird behavior with the imu.