### PR TITLE
Change drive functions to use joystick thresholding

### DIFF
--- a/include/ARMS/chassis.h
+++ b/include/ARMS/chassis.h
@@ -179,7 +179,8 @@ void init(std::initializer_list<okapi::Motor> leftMotors = {LEFT_MOTORS},
           double accel_step = ACCEL_STEP, double arc_step = ARC_STEP,
           int imuPort = IMU_PORT,
           std::tuple<int, int, int> encoderPorts = {ENCODER_PORTS},
-          int expanderPort = EXPANDER_PORT);
+          int expanderPort = EXPANDER_PORT,
+          int joystick_threshold = JOYSTICK_THRESHOLD);
 
 } // namespace chassis
 

--- a/include/ARMS/config.h
+++ b/include/ARMS/config.h
@@ -24,6 +24,10 @@ namespace chassis {
 #define IMU_PORT 0            // port 0 for disabled
 #define ENCODER_PORTS 0, 0, 0 // port 0 for disabled
 #define EXPANDER_PORT 0
+
+// joystick
+#define JOYSTICK_THRESHOLD 10 // min value needed for joystick to move drive
+
 } // namespace chassis
 
 namespace odom {

--- a/src/ARMS/chassis.cpp
+++ b/src/ARMS/chassis.cpp
@@ -46,6 +46,9 @@ double leftPrev = 0;
 double rightPrev = 0;
 bool useVelocity = false;
 
+// joystick threshold
+int joystick_threshold;
+
 /**************************************************/
 // basic control
 
@@ -521,7 +524,8 @@ void init(std::initializer_list<okapi::Motor> leftMotors,
           double distance_constant, double degree_constant, int settle_time,
           double settle_threshold_linear, double settle_threshold_angular,
           double accel_step, double arc_step, int imuPort,
-          std::tuple<int, int, int> encoderPorts, int expanderPort) {
+          std::tuple<int, int, int> encoderPorts, int expanderPort,
+          int joystick_threshold) {
 
 	// assign constants
 	chassis::distance_constant = distance_constant;
@@ -531,6 +535,7 @@ void init(std::initializer_list<okapi::Motor> leftMotors,
 	chassis::settle_threshold_angular = settle_threshold_angular;
 	chassis::accel_step = accel_step;
 	chassis::arc_step = arc_step;
+	chassis::joystick_threshold = joystick_threshold;
 
 	// configure chassis motors
 	chassis::leftMotors = std::make_shared<okapi::MotorGroup>(leftMotors);
@@ -580,18 +585,34 @@ void init(std::initializer_list<okapi::Motor> leftMotors,
 // operator control
 void tank(int left_speed, int right_speed) {
 	pid::mode = DISABLE; // turns off autonomous tasks
+
+	// apply thresholding
+	left_speed = (abs(left_speed) > joystick_threshold ? left_speed : 0);
+	right_speed = (abs(right_speed) > joystick_threshold ? right_speed : 0);
+
 	motorMove(leftMotors, left_speed, false);
 	motorMove(rightMotors, right_speed, false);
 }
 
 void arcade(int vertical, int horizontal) {
 	pid::mode = DISABLE; // turns off autonomous task
+
+	// apply thresholding
+	vertical = (abs(vertical) > joystick_threshold ? vertical : 0);
+	horizontal = (abs(horizontal) > joystick_threshold ? horizontal : 0);
+
 	motorMove(leftMotors, vertical + horizontal, false);
 	motorMove(rightMotors, vertical - horizontal, false);
 }
 
 void holonomic(int x, int y, int z) {
 	pid::mode = 0; // turns off autonomous task
+
+	// apply thresholding
+	x = (abs(x) > joystick_threshold ? x : 0);
+	y = (abs(y) > joystick_threshold ? y : 0);
+	z = (abs(z) > joystick_threshold ? z : 0);
+
 	motorMove(frontLeft, x + y + z, false);
 	motorMove(frontRight, x - y - z, false);
 	motorMove(backLeft, x + y - z, false);


### PR DESCRIPTION
Driver controls will now use a threshold to prevent the drive motors from always having power applied. The threshold variable can be tuned in the config.h file.

This should probably be tested on a robot before merging.