### PR TITLE
Allow chassis::velocity to be called with separate velocities

### DIFF
--- a/include/ARMS/chassis.h
+++ b/include/ARMS/chassis.h
@@ -122,6 +122,12 @@ void voltage(int t, int left_speed = 100, int right_speed = 0);
 void velocity(int t, int max = 100);
 
 /**
+ * Move for a duration at a set velocity using internal PID with different
+ * velocities for each side of the drive
+ */
+void velocity(int t, int left_max, int right_max);
+
+/**
  * Move the robot in an arc with a set length, radius, and speed
  */
 void arcLeft(int length, double rad, int max = 100, int type = 0);

--- a/include/ARMS/chassis.h
+++ b/include/ARMS/chassis.h
@@ -114,18 +114,12 @@ void fast(double sp, int max = 100);
 /**
  * Move for a duration at a set voltage with no PID
  */
-void voltage(int t, int left_speed = 100, int right_speed = 0);
+void voltage(int t, int left_speed = 100, int right_speed = 101);
 
 /**
  * Move for a duration at a set velocity using internal PID
  */
-void velocity(int t, int max = 100);
-
-/**
- * Move for a duration at a set velocity using internal PID with different
- * velocities for each side of the drive
- */
-void velocity(int t, int left_max, int right_max);
+void velocity(int t, int left_max = 100, int right_max = 101);
 
 /**
  * Move the robot in an arc with a set length, radius, and speed

--- a/src/ARMS/chassis.cpp
+++ b/src/ARMS/chassis.cpp
@@ -315,19 +315,13 @@ void fast(double sp, int max) {
 
 void voltage(int t, int left_speed, int right_speed) {
 	motorMove(leftMotors, left_speed, false);
-	motorMove(rightMotors, right_speed == 0 ? left_speed : right_speed, false);
-	delay(t);
-}
-
-void velocity(int t, int max) {
-	motorMove(leftMotors, max, true);
-	motorMove(rightMotors, max, true);
+	motorMove(rightMotors, right_speed == 101 ? left_speed : right_speed, false);
 	delay(t);
 }
 
 void velocity(int t, int left_max, int right_max) {
 	motorMove(leftMotors, left_max, true);
-	motorMove(rightMotors, right_max, true);
+	motorMove(rightMotors, right_max == 101 ? left_max : right_max, true);
 	delay(t);
 }
 

--- a/src/ARMS/chassis.cpp
+++ b/src/ARMS/chassis.cpp
@@ -325,6 +325,12 @@ void velocity(int t, int max) {
 	delay(t);
 }
 
+void velocity(int t, int left_max, int right_max) {
+	motorMove(leftMotors, left_max, true);
+	motorMove(rightMotors, right_max, true);
+	delay(t);
+}
+
 void arc(bool mirror, int arc_length, double rad, int max, int type) {
 	reset();
 	int time_step = 0;


### PR DESCRIPTION
The chassis::velocity function can now be called with two separate velocities for the left and right sides of the drive.