### PR TITLE
T1030 Fix linear PID bug

### DIFF
--- a/include/ARMS/pid.h
+++ b/include/ARMS/pid.h
@@ -24,7 +24,7 @@ extern double arcKP; // needs to be exposed since arcs have not been integrated
 
 extern double difKP; // needs to be exposed for use with chassis::fast
 
-std::array<double, 2> linear(bool rightSide = false);
+std::array<double, 2> linear();
 double angular();
 std::array<double, 2> gtp();
 

--- a/include/ARMS/pid.h
+++ b/include/ARMS/pid.h
@@ -24,7 +24,7 @@ extern double arcKP; // needs to be exposed since arcs have not been integrated
 
 extern double difKP; // needs to be exposed for use with chassis::fast
 
-double linear(bool rightSide = false);
+std::array<double, 2> linear(bool rightSide = false);
 double angular();
 std::array<double, 2> gtp();
 

--- a/src/ARMS/chassis.cpp
+++ b/src/ARMS/chassis.cpp
@@ -435,22 +435,21 @@ int chassisTask() {
 	while (1) {
 		delay(10);
 
-		double leftSpeed = 0;
-		double rightSpeed = 0;
+		std::array<double, 2> speeds = {0, 0}; // left, right
 
 		if (pid::mode == LINEAR) {
-			leftSpeed = pid::linear();
-			rightSpeed = pid::linear(true); // dif pid for right side
+			speeds = pid::gtp();
 		} else if (pid::mode == ANGULAR) {
-			rightSpeed = pid::angular();
-			leftSpeed = -rightSpeed;
+			speeds[1] = pid::angular();
+			speeds[0] = -speeds[1];
 		} else if (pid::mode == GTP) {
-			std::array<double, 2> speeds = pid::gtp();
-			leftSpeed = speeds[0];
-			rightSpeed = speeds[1];
+			speeds = pid::gtp();
 		} else {
 			continue;
 		}
+
+		double leftSpeed = speeds[0];
+		double rightSpeed = speeds[1];
 
 		// speed limiting
 		leftSpeed = limitSpeed(leftSpeed);

--- a/src/ARMS/pid.cpp
+++ b/src/ARMS/pid.cpp
@@ -36,7 +36,7 @@ double pid(double target, double sv, double* pe, double kp, double kd) {
 	return pid(error, pe, kp, kd);
 }
 
-double linear(bool rightSide) {
+std::array<double, 2> linear() {
 	static double pe = 0; // previous error
 
 	// get position in the x and y directions
@@ -54,12 +54,7 @@ double linear(bool rightSide) {
 
 	// difference PID
 	double dif = chassis::difference() * difKP;
-	if (rightSide)
-		speed += dif;
-	else
-		speed -= dif;
-
-	return speed;
+	return {speed -= dif, speed += dif};
 }
 
 double angular() {


### PR DESCRIPTION
The linear PID bug has been fixed by changing from running the same PID twice, once for each side, to running them both at once. We now return the speeds as an array, which we were already doing for the goToPoint functions.