### PR TITLE
T1029 - PID error print statement for debugging

### DIFF
--- a/include/ARMS/config.h
+++ b/include/ARMS/config.h
@@ -34,6 +34,8 @@ namespace odom {
 } // namespace odom
 
 namespace pid {
+#define PID_DEBUG false
+
 // normal pid constants
 #define LINEAR_KP .3
 #define LINEAR_KD .5

--- a/include/ARMS/pid.h
+++ b/include/ARMS/pid.h
@@ -28,8 +28,9 @@ double linear(bool rightSide = false);
 double angular();
 std::array<double, 2> gtp();
 
-void init(double linearKP = LINEAR_KP, double linearKD = LINEAR_KD,
-          double angularKP = ANGULAR_KP, double angularKD = ANGULAR_KD,
+void init(bool debug = PID_DEBUG, double linearKP = LINEAR_KP,
+          double linearKD = LINEAR_KD, double angularKP = ANGULAR_KP,
+          double angularKD = ANGULAR_KD,
           double linear_pointKP = LINEAR_POINT_KP,
           double linear_pointKD = LINEAR_POINT_KD,
           double angular_pointKP = ANGULAR_POINT_KP,

--- a/src/ARMS/pid.cpp
+++ b/src/ARMS/pid.cpp
@@ -5,6 +5,7 @@
 namespace pid {
 
 int mode = DISABLE;
+bool debug = false;
 
 // pid constants
 double linearKP;
@@ -25,6 +26,9 @@ double vectorAngle = 0;
 std::array<double, 2> pointTarget{0, 0};
 
 double pid(double error, double* pe, double kp, double kd) {
+	if (debug)
+		printf("%.2f\n", error);
+
 	double derivative = error - *pe;
 	double speed = error * kp + derivative * kd;
 	*pe = error;
@@ -126,10 +130,12 @@ std::array<double, 2> gtp() {
 	return {left_speed, right_speed};
 }
 
-void init(double linearKP, double linearKD, double angularKP, double angularKD,
-          double linear_pointKP, double linear_pointKD, double angular_pointKP,
-          double angular_pointKD, double arcKP, double difKP) {
+void init(bool debug, double linearKP, double linearKD, double angularKP,
+          double angularKD, double linear_pointKP, double linear_pointKD,
+          double angular_pointKP, double angular_pointKD, double arcKP,
+          double difKP) {
 
+	pid::debug = debug;
 	pid::linearKP = linearKP;
 	pid::linearKD = linearKD;
 	pid::angularKP = angularKP;


### PR DESCRIPTION
Added a debug option for the PID controllers to assist with tuning. This will make it much easier to see if the robots are travelling the desired distances/angles.