### PR TITLE
T1052 - Odom Quality of Life Improvements

### DIFF
--- a/include/ARMS/config.h
+++ b/include/ARMS/config.h
@@ -35,6 +35,7 @@ namespace odom {
 #define MIDDLE_TPI 41.4           // Ticks per inch
 #define SLEW_STEP 10              // point function slew
 #define HOLONOMIC 1               // holonomic chassis odom
+#define EXIT_ERROR 10 // exit distance for moveThru and holoThru movements
 } // namespace odom
 
 namespace pid {

--- a/include/ARMS/odom.h
+++ b/include/ARMS/odom.h
@@ -13,6 +13,8 @@ extern double prev_right_pos;
 extern double prev_left_pos;
 extern double prev_middle_pos;
 
+void reset(std::array<double, 2> point = {0, 0}, double angle = 0);
+
 double getAngleError(std::array<double, 2> point);
 
 double getDistanceError(std::array<double, 2> point);
@@ -23,13 +25,18 @@ void holoAsync(std::array<double, 2> point, double angle, double max = 80);
 
 void move(std::array<double, 2> point, double max = 80);
 
+void moveThru(std::array<double, 2> point, double max = 80);
+
 void holo(std::array<double, 2> point, double angle, double max = 80);
+
+void holoThru(std::array<double, 2> point, double angle, double max = 80);
 
 void init(bool debug = ODOM_DEBUG,
           double left_right_distance = LEFT_RIGHT_DISTANCE,
           double middle_distance = MIDDLE_DISTANCE,
           double left_right_tpi = LEFT_RIGHT_TPI,
-          double middle_tpi = MIDDLE_TPI, bool holonomic = HOLONOMIC);
+          double middle_tpi = MIDDLE_TPI, bool holonomic = HOLONOMIC,
+          double exit_error = EXIT_ERROR);
 
 } // namespace odom
 

--- a/src/ARMS/chassis.cpp
+++ b/src/ARMS/chassis.cpp
@@ -83,10 +83,6 @@ void reset() {
 	odom::prev_right_pos = 0;
 	odom::prev_middle_pos = 0;
 
-	for (int i = 0; i < 4; i++) {
-		output_prev[i] = 0;
-	}
-
 	settle_count = 0;
 
 	pid::vectorAngle = 0;


### PR DESCRIPTION
- The odometry position can now be reset.
- Several odometry based movements can be chained together using `odom::moveThru()` and `odom::holoThru`