### PR TITLE
T1053 - Race Condition Bug

### DIFF
--- a/src/ARMS/chassis.cpp
+++ b/src/ARMS/chassis.cpp
@@ -230,11 +230,11 @@ void waitUntilSettled() {
 /**************************************************/
 // autonomous functions
 void moveAsync(double sp, int max) {
+	pid::mode = LINEAR;
 	sp *= distance_constant;
 	reset();
 	maxSpeed = max;
 	pid::linearTarget = sp;
-	pid::mode = LINEAR;
 }
 
 void turnAsync(double sp, int max) {


### PR DESCRIPTION
There is a very small delay in the reset function, which allows other threads to take priority. If the chassis thread takes priority during that delay, and the chassis is still in holonomic odom mode, then the vector angle will be changed to a non-zero number. The linear chassis movements require the vector angle to be zero to function properly. This is because linear movements are only in one dimension and should not be doing any 2D vector math. To fix this, the pid mode set to linear _before_ calling the reset function. This eliminates the race condition.