### PR TITLE
Clockwise As Positive

### DIFF
--- a/include/ARMS/chassis.h
+++ b/include/ARMS/chassis.h
@@ -51,7 +51,7 @@ void reset();
 double position(bool yDirection = false);
 
 /**
- * Get the angle of the chassis
+ * Get the angle of the chassis in degrees
  */
 double angle();
 

--- a/include/ARMS/pid.h
+++ b/include/ARMS/pid.h
@@ -26,7 +26,7 @@ extern double arcKP; // needs to be exposed since arcs have not been integrated
 extern double difKP; // needs to be exposed for use with chassis::fast
 
 std::array<double, 2> linear();
-double angular();
+std::array<double, 2> angular();
 std::array<double, 2> odom();
 
 void init(bool debug = PID_DEBUG, double linearKP = LINEAR_KP,

--- a/src/ARMS/chassis.cpp
+++ b/src/ARMS/chassis.cpp
@@ -140,9 +140,9 @@ double position(bool yDirection) {
 
 double angle() {
 	if (imu) {
-		return -imu->get_rotation();
+		return imu->get_rotation();
 	} else {
-		return (-getEncoders()[0] + getEncoders()[1]) / 2;
+		return (getEncoders()[0] - getEncoders()[1]) / 2 / degree_constant;
 	}
 }
 
@@ -239,12 +239,7 @@ void moveAsync(double sp, int max) {
 
 void turnAsync(double sp, int max) {
 	pid::mode = ANGULAR;
-
-	if (imu)
-		sp += position();
-	else
-		sp *= degree_constant;
-
+	sp += position();
 	reset();
 	maxSpeed = max;
 	pid::angularTarget = sp;
@@ -341,8 +336,7 @@ int chassisTask() {
 		if (pid::mode == LINEAR) {
 			speeds = pid::linear();
 		} else if (pid::mode == ANGULAR) {
-			speeds[1] = pid::angular();
-			speeds[0] = -speeds[1];
+			speeds = pid::angular();
 		} else if (pid::mode == ODOM || pid::mode == ODOM_HOLO) {
 			speeds = pid::odom();
 		} else {
@@ -386,14 +380,14 @@ int chassisTask() {
 			double turnSpeed = rightSpeed - leftSpeed;
 			turnSpeed = limitSpeed(turnSpeed, 50);
 
-			output[0] = frontVector - turnSpeed;
-			output[1] = backVector - turnSpeed;
-			output[2] = backVector + turnSpeed;
-			output[3] = frontVector + turnSpeed;
+			output[0] = frontVector - turnSpeed; // front left
+			output[1] = backVector - turnSpeed;  // back left
+			output[2] = backVector + turnSpeed;  // front right
+			output[3] = frontVector + turnSpeed; // back right
 
 		} else {
-			output[0] = output[1] = leftSpeed;
-			output[2] = output[3] = rightSpeed;
+			output[0] = output[1] = leftSpeed;  // left motors
+			output[2] = output[3] = rightSpeed; // right motors
 		}
 
 		for (int i = 0; i < 4; i++) {

--- a/src/ARMS/odom.cpp
+++ b/src/ARMS/odom.cpp
@@ -59,7 +59,7 @@ int odomTask() {
 		// calculate new heading
 		double delta_angle;
 		if (chassis::imu) {
-			heading_degrees = chassis::imu->get_rotation();
+			heading_degrees = chassis::angle();
 			heading = heading_degrees * M_PI / 180.0;
 			delta_angle = heading - prev_heading;
 		} else {

--- a/src/ARMS/pid.cpp
+++ b/src/ARMS/pid.cpp
@@ -62,11 +62,11 @@ std::array<double, 2> linear() {
 	return {speed -= dif, speed += dif};
 }
 
-double angular() {
+std::array<double, 2> angular() {
 	static double pe = 0; // previous error
 	double sv = chassis::angle();
 	double speed = pid(angularTarget, sv, &pe, angularKP, angularKD);
-	return speed;
+	return {speed, -speed}; // clockwise positive
 }
 
 std::array<double, 2> odom() {


### PR DESCRIPTION
The chassis angle now always measures in degrees rather than converting later on during the turning functions. Additionally, odometry calculations, chassis angle calculations, and turning instructions for motors are now unified in treating clockwise as positive.