### PR TITLE
T1081 - Odom turn speed parameter

### DIFF
--- a/include/ARMS/chassis.h
+++ b/include/ARMS/chassis.h
@@ -11,6 +11,7 @@ extern double accel_step;
 extern double distance_constant;
 extern double width;
 extern double maxSpeed;
+extern double maxTurn;
 
 extern std::shared_ptr<okapi::Motor> frontLeft;
 extern std::shared_ptr<okapi::Motor> frontRight;

--- a/include/ARMS/odom.h
+++ b/include/ARMS/odom.h
@@ -21,15 +21,18 @@ double getDistanceError(std::array<double, 2> point);
 
 void moveAsync(std::array<double, 2> point, double max = 80);
 
-void holoAsync(std::array<double, 2> point, double angle, double max = 80);
+void holoAsync(std::array<double, 2> point, double angle, double max = 80,
+               double turnMax = 50);
 
 void move(std::array<double, 2> point, double max = 80);
 
 void moveThru(std::array<double, 2> point, double max = 80);
 
-void holo(std::array<double, 2> point, double angle, double max = 80);
+void holo(std::array<double, 2> point, double angle, double max = 80,
+          double turnMax = 50);
 
-void holoThru(std::array<double, 2> point, double angle, double max = 80);
+void holoThru(std::array<double, 2> point, double angle, double max = 80,
+              double turnMax = 50);
 
 void init(bool debug = ODOM_DEBUG,
           double left_right_distance = LEFT_RIGHT_DISTANCE,

--- a/src/ARMS/chassis.cpp
+++ b/src/ARMS/chassis.cpp
@@ -42,6 +42,7 @@ double arc_step;   // acceleration for arcs
 
 // chassis variables
 double maxSpeed = 100;
+double maxTurn = 100;
 double maxAngular = 50; // holonomic odom only
 double output_prev[4] = {0, 0, 0, 0};
 bool useVelocity = false;
@@ -378,7 +379,7 @@ int chassisTask() {
 			backVector *= scalingFactor;
 
 			double turnSpeed = rightSpeed - leftSpeed;
-			turnSpeed = limitSpeed(turnSpeed, 50);
+			turnSpeed = limitSpeed(turnSpeed, maxTurn);
 
 			output[0] = frontVector - turnSpeed; // front left
 			output[1] = backVector - turnSpeed;  // back left

--- a/src/ARMS/odom.cpp
+++ b/src/ARMS/odom.cpp
@@ -143,9 +143,11 @@ void moveAsync(std::array<double, 2> point, double max) {
 	pid::mode = ODOM;
 }
 
-void holoAsync(std::array<double, 2> point, double angle, double max) {
+void holoAsync(std::array<double, 2> point, double angle, double max,
+               double turnMax) {
 	chassis::reset();
 	chassis::maxSpeed = max;
+	chassis::maxTurn = turnMax;
 	pid::pointTarget = point;
 	pid::angularTarget = angle;
 	pid::mode = ODOM_HOLO;
@@ -164,14 +166,16 @@ void moveThru(std::array<double, 2> point, double max) {
 		delay(10);
 }
 
-void holo(std::array<double, 2> point, double angle, double max) {
-	holoAsync(point, angle, max);
+void holo(std::array<double, 2> point, double angle, double max,
+          double turnMax) {
+	holoAsync(point, angle, max, turnMax);
 	delay(450);
 	chassis::waitUntilSettled();
 }
 
-void holoThru(std::array<double, 2> point, double angle, double max) {
-	holoAsync(point, angle, max);
+void holoThru(std::array<double, 2> point, double angle, double max,
+              double turnMax) {
+	holoAsync(point, angle, max, turnMax);
 	delay(450);
 	while (getDistanceError(point) > exit_error)
 		delay(10);


### PR DESCRIPTION
Turn speed can now be adjusted with a parameter in the function call. This allows us to make the rate of turn much higher for short movements to make sure we hit the target angle before reaching the target point.