### PR TITLE
T1086 - Fix bug comparing with PID mode check

### DIFF
--- a/src/ARMS/chassis.cpp
+++ b/src/ARMS/chassis.cpp
@@ -375,7 +375,7 @@ int chassisTask() {
 				largestSpeed = rightSpeed;
 
 			double scalingFactor;
-			if (ODOM_HOLO_THRU)
+			if (pid::mode == ODOM_HOLO_THRU)
 				scalingFactor = fabs(maxSpeed) / fabs(largestVector);
 			else
 				scalingFactor = fabs(largestSpeed) / fabs(largestVector);


### PR DESCRIPTION
A bug in an if statement always returned true. This caused PID to never run, even though it should for normal holonomic movements.