### PR TITLE
T1026

### DIFF
--- a/src/ARMS/chassis.cpp
+++ b/src/ARMS/chassis.cpp
@@ -527,8 +527,8 @@ void holonomic(int y, int x, int z) {
 
 	motorMove(frontLeft, y + x + z, false);
 	motorMove(frontRight, y - x - z, false);
-	motorMove(backLeft, y + x - z, false);
-	motorMove(backRight, y - x + z, false);
+	motorMove(backLeft, y - x + z, false);
+	motorMove(backRight, y + x - z, false);
 }
 
 } // namespace chassis

--- a/src/ARMS/chassis.cpp
+++ b/src/ARMS/chassis.cpp
@@ -517,18 +517,18 @@ void arcade(int vertical, int horizontal) {
 	motorMove(rightMotors, vertical - horizontal, false);
 }
 
-void holonomic(int x, int y, int z) {
+void holonomic(int y, int x, int z) {
 	pid::mode = DISABLE; // turns off autonomous task
 
 	// apply thresholding
-	x = (abs(x) > joystick_threshold ? x : 0);
 	y = (abs(y) > joystick_threshold ? y : 0);
+	x = (abs(x) > joystick_threshold ? x : 0);
 	z = (abs(z) > joystick_threshold ? z : 0);
 
-	motorMove(frontLeft, x + y + z, false);
-	motorMove(frontRight, x - y - z, false);
-	motorMove(backLeft, x + y - z, false);
-	motorMove(backRight, x - y + z, false);
+	motorMove(frontLeft, y + x + z, false);
+	motorMove(frontRight, y - x - z, false);
+	motorMove(backLeft, y + x - z, false);
+	motorMove(backRight, y - x + z, false);
 }
 
 } // namespace chassis

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,14 +25,8 @@ void opcontrol() {
 		if (master.get_digital(DIGITAL_LEFT) && !competition::is_connected())
 			autonomous();
 
-		/*	
 		chassis::arcade(master.get_analog(ANALOG_LEFT_Y) * (double)100 / 127,
 		                master.get_analog(ANALOG_RIGHT_X) * (double)100 / 127);
-		*/
-
-		chassis::holonomic(master.get_analog(ANALOG_LEFT_Y) * (double)100 / 127,
-						master.get_analog(ANALOG_RIGHT_X) * (double)100 / 127,
-						master.get_analog(ANALOG_LEFT_X) * (double)100 / 127);
 
 		pros::delay(10);
 	}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,8 +25,14 @@ void opcontrol() {
 		if (master.get_digital(DIGITAL_LEFT) && !competition::is_connected())
 			autonomous();
 
+		/*	
 		chassis::arcade(master.get_analog(ANALOG_LEFT_Y) * (double)100 / 127,
 		                master.get_analog(ANALOG_RIGHT_X) * (double)100 / 127);
+		*/
+
+		chassis::holonomic(master.get_analog(ANALOG_LEFT_Y) * (double)100 / 127,
+						master.get_analog(ANALOG_RIGHT_X) * (double)100 / 127,
+						master.get_analog(ANALOG_LEFT_X) * (double)100 / 127);
 
 		pros::delay(10);
 	}


### PR DESCRIPTION
Reordered the various holonomic joystick axis's to actually represent what they are labeled as. Previously, the holonomic chassis control inputs did not match up with the desired outputs whatsoever.