### PR TITLE
T1139 Remove imu init delay

### DIFF
--- a/src/ARMS/chassis.cpp
+++ b/src/ARMS/chassis.cpp
@@ -471,13 +471,8 @@ void init(std::initializer_list<okapi::Motor> leftMotors,
 	if (imuPort != 0) {
 		imu = std::make_shared<Imu>(imuPort);
 		imu->reset();
-		delay(1500);
-		while (imu->is_calibrating()) {
-			delay(10);
-		}
-		delay(1000);
-		// printf("IMU calibrated!");
 	}
+	
 	// configure individual motors for holonomic chassis
 	chassis::frontLeft = std::make_shared<okapi::Motor>(*leftMotors.begin());
 	chassis::backLeft = std::make_shared<okapi::Motor>(*(leftMotors.end() - 1));

--- a/src/ARMS/chassis.cpp
+++ b/src/ARMS/chassis.cpp
@@ -472,7 +472,7 @@ void init(std::initializer_list<okapi::Motor> leftMotors,
 		imu = std::make_shared<Imu>(imuPort);
 		imu->reset();
 	}
-	
+
 	// configure individual motors for holonomic chassis
 	chassis::frontLeft = std::make_shared<okapi::Motor>(*leftMotors.begin());
 	chassis::backLeft = std::make_shared<okapi::Motor>(*(leftMotors.end() - 1));


### PR DESCRIPTION
The imu had an unnecessarily long initialization delay. We should still let it sit for a few seconds when running autons, but removing this delay will be less annoying when just doing driver control stuff.