### PR TITLE
Wrap existing namespaces in arms namespace, bump version to 1.4.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ EXCLUDE_COLD_LIBRARIES:=
 IS_LIBRARY:=1
 
 LIBNAME:=ARMS
-VERSION:=1.3.2
+VERSION:=1.4.0
 # EXCLUDE_SRC_FROM_LIB= $(SRCDIR)/unpublishedfile.c
 # this line excludes opcontrol.c and similar files
 EXCLUDE_SRC_FROM_LIB+=$(foreach file, $(SRCDIR)/main,$(foreach cext,$(CEXTS),$(file).$(cext)) $(foreach cxxext,$(CXXEXTS),$(file).$(cxxext)))

--- a/include/ARMS/api.h
+++ b/include/ARMS/api.h
@@ -6,3 +6,5 @@
 #include "ARMS/pid.h"
 #include "ARMS/purepursuit.h"
 #include "ARMS/selector.h"
+
+using namespace arms;

--- a/include/ARMS/api.h
+++ b/include/ARMS/api.h
@@ -7,4 +7,4 @@
 #include "ARMS/purepursuit.h"
 #include "ARMS/selector.h"
 
-using namespace arms;
+// using namespace arms;

--- a/include/ARMS/arc.h
+++ b/include/ARMS/arc.h
@@ -1,5 +1,5 @@
-#ifndef _ARC_H_
-#define _ARC_H_
+#ifndef _ARMS_ARC_H_
+#define _ARMS_ARC_H_
 
 namespace arms::chassis {
 

--- a/include/ARMS/arc.h
+++ b/include/ARMS/arc.h
@@ -1,7 +1,7 @@
 #ifndef _ARC_H_
 #define _ARC_H_
 
-namespace chassis {
+namespace arms::chassis {
 
 /**
  * Move the robot in an arc with a set length, radius, and speed
@@ -33,6 +33,6 @@ void _sLeft(int arc1, int mid, int arc2, int max = 100);
  */
 void _sRight(int arc1, int mid, int arc2, int max = 100);
 
-} // namespace chassis
+} // namespace arms::chassis
 
 #endif

--- a/include/ARMS/chassis.h
+++ b/include/ARMS/chassis.h
@@ -4,7 +4,7 @@
 #include "ARMS/config.h"
 #include "okapi/api.hpp"
 
-namespace chassis {
+namespace arms::chassis {
 
 extern bool useVelocity;
 extern double accel_step;
@@ -174,6 +174,6 @@ void init(std::initializer_list<okapi::Motor> leftMotors = {LEFT_MOTORS},
           int expanderPort = EXPANDER_PORT,
           int joystick_threshold = JOYSTICK_THRESHOLD);
 
-} // namespace chassis
+} // namespace arms::chassis
 
 #endif

--- a/include/ARMS/chassis.h
+++ b/include/ARMS/chassis.h
@@ -1,5 +1,5 @@
-#ifndef _CHASSIS_H_
-#define _CHASSIS_H_
+#ifndef _ARMS_CHASSIS_H_
+#define _ARMS_CHASSIS_H_
 
 #include "ARMS/config.h"
 #include "okapi/api.hpp"

--- a/include/ARMS/config.h
+++ b/include/ARMS/config.h
@@ -2,7 +2,7 @@
 #define _CONFIG_H_
 
 // Drivetrain configuration constants
-namespace chassis {
+namespace arms::chassis {
 // negative numbers mean reversed motor
 #define LEFT_MOTORS 1, 2
 #define RIGHT_MOTORS -3, -4
@@ -25,9 +25,9 @@ namespace chassis {
 #define ENCODER_PORTS 0, 0, 0 // port 0 for disabled
 #define EXPANDER_PORT 0
 #define JOYSTICK_THRESHOLD 10 // min value needed for joystick to move drive
-} // namespace chassis
+} // namespace arms::chassis
 
-namespace odom {
+namespace arms::odom {
 #define ODOM_DEBUG 1
 #define LEFT_RIGHT_DISTANCE 6.375 // only needed for non-imu setups
 #define MIDDLE_DISTANCE 5.75      // only needed if using middle tracker
@@ -36,9 +36,9 @@ namespace odom {
 #define SLEW_STEP 10              // point function slew
 #define HOLONOMIC 1               // holonomic chassis odom
 #define EXIT_ERROR 10 // exit distance for moveThru and holoThru movements
-} // namespace odom
+} // namespace arms::odom
 
-namespace pid {
+namespace arms::pid {
 #define PID_DEBUG false
 
 // normal pid constants
@@ -59,14 +59,14 @@ namespace pid {
 #define ANGULAR_POINT_KI 0
 #define ANGULAR_POINT_KD 0
 #define MIN_ERROR 5 // minimum error, stops robot from spinning around point
-} // namespace pid
+} // namespace arms::pid
 
 // Auton selector configuration constants
-namespace selector {
+namespace arms::selector {
 // Names of autonomi, up to 10
 #define AUTONS "Front", "Back", "Do Nothing"
 #define HUE 360   // Color of theme from 0-359(H part of HSV)
 #define DEFAULT 1 // Default auton numbers
-} // namespace selector
+} // namespace arms::selector
 
 #endif

--- a/include/ARMS/config.h
+++ b/include/ARMS/config.h
@@ -1,5 +1,5 @@
-#ifndef _CONFIG_H_
-#define _CONFIG_H_
+#ifndef _ARMS_CONFIG_H_
+#define _ARMS_CONFIG_H_
 
 // Drivetrain configuration constants
 namespace arms::chassis {

--- a/include/ARMS/odom.h
+++ b/include/ARMS/odom.h
@@ -1,5 +1,5 @@
-#ifndef _ODOM_H_
-#define _ODOM_H_
+#ifndef _ARMS_ODOM_H_
+#define _ARMS_ODOM_H_
 
 #include "ARMS/config.h"
 #include <array>

--- a/include/ARMS/odom.h
+++ b/include/ARMS/odom.h
@@ -4,7 +4,7 @@
 #include "ARMS/config.h"
 #include <array>
 
-namespace odom {
+namespace arms::odom {
 
 extern double global_x;
 extern double global_y;
@@ -44,6 +44,6 @@ void init(bool debug = ODOM_DEBUG,
           double middle_tpi = MIDDLE_TPI, bool holonomic = HOLONOMIC,
           double exit_error = EXIT_ERROR);
 
-} // namespace odom
+} // namespace arms::odom
 
 #endif

--- a/include/ARMS/pid.h
+++ b/include/ARMS/pid.h
@@ -1,5 +1,5 @@
-#ifndef _PIDA_H_
-#define _PIDA_H_
+#ifndef _ARMS_PID_H_
+#define _ARMS_PID_H_
 
 #include "ARMS/config.h"
 #include <array>

--- a/include/ARMS/pid.h
+++ b/include/ARMS/pid.h
@@ -4,7 +4,7 @@
 #include "ARMS/config.h"
 #include <array>
 
-namespace pid {
+namespace arms::pid {
 
 // pid mode enums
 #define ODOM_HOLO_THRU 5
@@ -42,6 +42,6 @@ void init(bool debug = PID_DEBUG, double linearKP = LINEAR_KP,
           double angular_pointKD = ANGULAR_POINT_KD, double arcKP = ARC_KP,
           double difKP = DIF_KP, double min_error = MIN_ERROR);
 
-} // namespace pid
+} // namespace arms::pid
 
 #endif

--- a/include/ARMS/purepursuit.h
+++ b/include/ARMS/purepursuit.h
@@ -1,5 +1,5 @@
-#ifndef _PURE_PURSUIT_H_
-#define _PURE_PURSUIT_H_
+#ifndef _ARMS_PURE_PURSUIT_H_
+#define _ARMS_PURE_PURSUIT_H_
 
 #include <array>
 #include <vector>

--- a/include/ARMS/purepursuit.h
+++ b/include/ARMS/purepursuit.h
@@ -4,13 +4,14 @@
 #include <array>
 #include <vector>
 
-namespace purepursuit {
+namespace arms::purepursuit {
 
-std::array<double,2> findIntersectionPoint(std::vector<std::array<double, 2>> path, double radius);
+std::array<double, 2>
+findIntersectionPoint(std::vector<std::array<double, 2>> path, double radius);
 
 void goToPoint(std::vector<std::array<double, 2>> path);
 void followPath(std::vector<std::array<double, 2>> path);
 
-} // namespace purepursuit
+} // namespace arms::purepursuit
 
 #endif

--- a/include/ARMS/selector.h
+++ b/include/ARMS/selector.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef _ARMS_SELECTOR_H_
+#define _ARMS_SELECTOR_H_
 
 #include "ARMS/config.h"
 #include <string>
@@ -10,3 +11,5 @@ const char* b[] = {AUTONS, ""};
 void init(int hue = HUE, int default_auton = DEFAULT, const char** autons = b);
 
 } // namespace arms::selector
+
+#endif

--- a/include/ARMS/selector.h
+++ b/include/ARMS/selector.h
@@ -3,10 +3,10 @@
 #include "ARMS/config.h"
 #include <string>
 
-namespace selector {
+namespace arms::selector {
 
 extern int auton;
 const char* b[] = {AUTONS, ""};
 void init(int hue = HUE, int default_auton = DEFAULT, const char** autons = b);
 
-} // namespace selector
+} // namespace arms::selector

--- a/src/ARMS/arc.cpp
+++ b/src/ARMS/arc.cpp
@@ -5,7 +5,7 @@
 #include "api.h"
 using namespace pros;
 
-namespace chassis {
+namespace arms::chassis {
 
 double prev = 0; // previous chassis speed
 
@@ -112,4 +112,4 @@ void _sRight(int arc1, int mid, int arc2, int max) {
 	scurve(false, -arc1, -mid, -arc2, max);
 }
 
-} // namespace chassis
+} // namespace arms::chassis

--- a/src/ARMS/chassis.cpp
+++ b/src/ARMS/chassis.cpp
@@ -6,7 +6,7 @@
 
 using namespace pros;
 
-namespace chassis {
+namespace arms::chassis {
 
 // imu
 std::shared_ptr<Imu> imu;
@@ -538,4 +538,4 @@ void holonomic(double y, double x, double z) {
 	motorMove(backRight, y + x - z, false);
 }
 
-} // namespace chassis
+} // namespace arms::chassis

--- a/src/ARMS/odom.cpp
+++ b/src/ARMS/odom.cpp
@@ -5,7 +5,7 @@
 
 using namespace pros;
 
-namespace odom {
+namespace arms::odom {
 
 bool debug;
 double left_right_distance;
@@ -204,4 +204,4 @@ void init(bool debug, double left_right_distance, double middle_distance,
 	Task odom_task(odomTask);
 }
 
-} // namespace odom
+} // namespace arms::odom

--- a/src/ARMS/pid.cpp
+++ b/src/ARMS/pid.cpp
@@ -2,7 +2,7 @@
 #include "ARMS/chassis.h"
 #include "ARMS/odom.h"
 
-namespace pid {
+namespace arms::pid {
 
 int mode = DISABLE;
 bool debug = false;
@@ -202,4 +202,4 @@ void init(bool debug, double linearKP, double linearKI, double linearKD,
 	pid::min_error = min_error;
 }
 
-} // namespace pid
+} // namespace arms::pid

--- a/src/ARMS/purepursuit.cpp
+++ b/src/ARMS/purepursuit.cpp
@@ -5,7 +5,7 @@
 
 using namespace pros;
 
-namespace purepursuit {
+namespace arms::purepursuit {
 
 bool last_segment = false;
 double m, a, b, c;
@@ -208,4 +208,4 @@ void followPath(std::vector<std::array<double, 2>> path) {
 	}
 }
 
-} // namespace purepursuit
+} // namespace arms::purepursuit

--- a/src/ARMS/selector.cpp
+++ b/src/ARMS/selector.cpp
@@ -1,7 +1,7 @@
 #include "ARMS/selector.h"
 #include "main.h"
 
-namespace selector {
+namespace arms::selector {
 
 int auton;
 int autonCount;
@@ -132,4 +132,4 @@ void init(int hue, int default_auton, const char** autons) {
 	pros::Task tabWatcher_task(tabWatcher);
 }
 
-} // namespace selector
+} // namespace arms::selector

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,10 +3,10 @@
 pros::Controller master(CONTROLLER_MASTER);
 
 void initialize() {
-	chassis::init();
-	odom::init();
-	pid::init();
-	selector::init();
+	arms::chassis::init();
+	arms::odom::init();
+	arms::pid::init();
+	arms::selector::init();
 }
 
 void disabled() {
@@ -16,7 +16,7 @@ void competition_initialize() {
 }
 
 void autonomous() {
-	odom::move({24, 0});
+	arms::odom::move({24, 0});
 }
 
 void opcontrol() {
@@ -25,8 +25,9 @@ void opcontrol() {
 		if (master.get_digital(DIGITAL_LEFT) && !competition::is_connected())
 			autonomous();
 
-		chassis::arcade(master.get_analog(ANALOG_LEFT_Y) * (double)100 / 127,
-		                master.get_analog(ANALOG_RIGHT_X) * (double)100 / 127);
+		arms::chassis::arcade(master.get_analog(ANALOG_LEFT_Y) * (double)100 / 127,
+		                      master.get_analog(ANALOG_RIGHT_X) * (double)100 /
+		                          127);
 
 		pros::delay(10);
 	}


### PR DESCRIPTION
As per issue #66, to prevent conflict with end user code, all namespaces have been wrapped in a project-level 'arms' namespace.