### PR TITLE
Fix PID master/slave motors bug. Add pid 'difMax' parameter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ EXCLUDE_COLD_LIBRARIES:=
 IS_LIBRARY:=1
 
 LIBNAME:=ARMS
-VERSION:=1.4.0
+VERSION:=1.4.1
 # EXCLUDE_SRC_FROM_LIB= $(SRCDIR)/unpublishedfile.c
 # this line excludes opcontrol.c and similar files
 EXCLUDE_SRC_FROM_LIB+=$(foreach file, $(SRCDIR)/main,$(foreach cext,$(CEXTS),$(file).$(cext)) $(foreach cxxext,$(CXXEXTS),$(file).$(cxxext)))

--- a/include/ARMS/config.h
+++ b/include/ARMS/config.h
@@ -28,7 +28,7 @@ namespace arms::chassis {
 } // namespace arms::chassis
 
 namespace arms::odom {
-#define ODOM_DEBUG 1
+#define ODOM_DEBUG 0
 #define LEFT_RIGHT_DISTANCE 6.375 // only needed for non-imu setups
 #define MIDDLE_DISTANCE 5.75      // only needed if using middle tracker
 #define LEFT_RIGHT_TPI 41.4       // Ticks per inch
@@ -50,6 +50,7 @@ namespace arms::pid {
 #define ANGULAR_KD 3
 #define ARC_KP .05
 #define DIF_KP .5
+#define DIF_MAX 20
 
 // odom point constants
 #define LINEAR_POINT_KP 8

--- a/include/ARMS/pid.h
+++ b/include/ARMS/pid.h
@@ -25,6 +25,7 @@ extern double arcKP; // needs to be exposed since arcs have not been integrated
                      // into new PID format
 
 extern double difKP; // needs to be exposed for use with chassis::fast
+extern double dif;
 
 std::array<double, 2> linear();
 std::array<double, 2> angular();
@@ -40,7 +41,8 @@ void init(bool debug = PID_DEBUG, double linearKP = LINEAR_KP,
           double angular_pointKP = ANGULAR_POINT_KP,
           double angular_pointKI = ANGULAR_POINT_KI,
           double angular_pointKD = ANGULAR_POINT_KD, double arcKP = ARC_KP,
-          double difKP = DIF_KP, double min_error = MIN_ERROR);
+          double difKP = DIF_KP, double min_error = MIN_ERROR,
+          double difMax = DIF_MAX);
 
 } // namespace arms::pid
 

--- a/src/ARMS/chassis.cpp
+++ b/src/ARMS/chassis.cpp
@@ -485,6 +485,14 @@ void init(std::initializer_list<okapi::Motor> leftMotors,
 	chassis::frontRight->setGearing((okapi::AbstractMotor::gearset)gearset);
 	chassis::backRight->setGearing((okapi::AbstractMotor::gearset)gearset);
 
+	chassis::frontLeft->tarePosition();
+	chassis::backLeft->tarePosition();
+	chassis::frontRight->tarePosition();
+	chassis::backRight->tarePosition();
+
+	chassis::leftMotors->tarePosition();
+	chassis::rightMotors->tarePosition();
+
 	if (std::get<0>(encoderPorts) != 0) {
 		leftEncoder = initEncoder(std::get<0>(encoderPorts), expanderPort);
 	}

--- a/src/ARMS/pid.cpp
+++ b/src/ARMS/pid.cpp
@@ -95,8 +95,8 @@ std::array<double, 2> angular() {
 
 std::array<double, 2> odom() {
 	// previous sensor values
-	static double psv_left = 0;
-	static double psv_right = 0;
+	static double pe_lin = 0;
+	static double pe_ang = 0;
 
 	double lin_error = odom::getDistanceError(pointTarget); // linear
 	double ang_error = odom::getAngleError(pointTarget);    // angular
@@ -113,15 +113,11 @@ std::array<double, 2> odom() {
 			ang_error += 360;
 
 		// convert to radians
-		ang_error = ang_error * M_PI / 180;
+		ang_error *= -M_PI / 180;
 
 	} else if (lin_error < min_error) {
 		ang_error = 0; // prevent spinning
 	}
-
-	// previous error values
-	static double pe_lin = lin_error;
-	static double pe_ang = ang_error;
 
 	// integral values
 	static double in_lin;
@@ -140,15 +136,11 @@ std::array<double, 2> odom() {
 	double lin_speed = pid(lin_error, &pe_lin, &in_lin, linear_pointKP,
 	                       linear_pointKI, linear_pointKD);
 
-	// store previous previos error
-	pe_lin = lin_error;
-	pe_ang = ang_error;
-
 	lin_speed *= reverse; // apply reversal
 
 	// add speeds together
-	double left_speed = lin_speed + ang_speed;
-	double right_speed = lin_speed - ang_speed;
+	double left_speed = lin_speed - ang_speed;
+	double right_speed = lin_speed + ang_speed;
 
 	// speed scaling
 	if (left_speed > chassis::maxSpeed) {
@@ -170,7 +162,7 @@ std::array<double, 2> odom() {
 		left_speed -= diff;
 		right_speed -= diff;
 	}
-
+  printf("%.2f, %.2f\n", left_speed, right_speed);
 	return {left_speed, right_speed};
 }
 

--- a/src/ARMS/pid.cpp
+++ b/src/ARMS/pid.cpp
@@ -22,6 +22,8 @@ double angular_pointKI;
 double angular_pointKD;
 double arcKP;
 double difKP;
+double dif;
+double difMax;
 double min_error;
 
 // pid targets
@@ -76,15 +78,10 @@ std::array<double, 2> linear() {
 	speed = chassis::limitSpeed(speed, chassis::maxSpeed);
 
 	// difference PID
-	double dif = chassis::difference() * difKP;
+	dif = chassis::difference() * difKP;
+	dif = chassis::limitSpeed(dif, difMax);
 
-	// prevent oscillations near target
-	if (dif > speed && speed > 0)
-		dif = speed;
-	else if (dif < -speed && speed < 0)
-		dif = -speed;
-
-	return {speed -= dif, speed += dif};
+	return {speed - dif, speed + dif};
 }
 
 std::array<double, 2> angular() {
@@ -181,8 +178,8 @@ void init(bool debug, double linearKP, double linearKI, double linearKD,
           double angularKP, double angularKI, double angularKD,
           double linear_pointKP, double linear_pointKI, double linear_pointKD,
           double angular_pointKP, double angular_pointKI,
-          double angular_pointKD, double arcKP, double difKP,
-          double min_error) {
+          double angular_pointKD, double arcKP, double difKP, double min_error,
+          double difMax) {
 
 	pid::debug = debug;
 	pid::linearKP = linearKP;
@@ -200,6 +197,7 @@ void init(bool debug, double linearKP, double linearKI, double linearKD,
 	pid::arcKP = arcKP;
 	pid::difKP = difKP;
 	pid::min_error = min_error;
+	pid::difMax = difMax;
 }
 
 } // namespace arms::pid

--- a/src/ARMS/pid.cpp
+++ b/src/ARMS/pid.cpp
@@ -162,7 +162,7 @@ std::array<double, 2> odom() {
 		left_speed -= diff;
 		right_speed -= diff;
 	}
-  printf("%.2f, %.2f\n", left_speed, right_speed);
+	printf("%.2f, %.2f\n", left_speed, right_speed);
 	return {left_speed, right_speed};
 }
 


### PR DESCRIPTION
Fixes issue where the right side motors were master and the left side were slaves in the PID function. Adds 'difMax' value as a maximum value for the difference PID. Default is set to 20.