### PR TITLE
Add Auton Selector Destory Function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ EXCLUDE_COLD_LIBRARIES:=
 IS_LIBRARY:=1
 
 LIBNAME:=ARMS
-VERSION:=3.0.1
+VERSION:=3.0.2
 # EXCLUDE_SRC_FROM_LIB= $(SRCDIR)/unpublishedfile.c
 # this line excludes opcontrol.c and similar files
 EXCLUDE_SRC_FROM_LIB+=$(foreach file, $(SRCDIR)/main,$(foreach cext,$(CEXTS),$(file).$(cext)) $(foreach cxxext,$(CXXEXTS),$(file).$(cxxext)))

--- a/include/ARMS/selector.h
+++ b/include/ARMS/selector.h
@@ -6,6 +6,7 @@ namespace arms::selector {
 extern int auton;
 void init(int hue, int default_auton, const char** autons);
 
+void destroy();
 } // namespace arms::selector
 
 #endif

--- a/src/ARMS/selector.cpp
+++ b/src/ARMS/selector.cpp
@@ -11,7 +11,7 @@ lv_obj_t* tabview;
 lv_obj_t* redBtnm;
 lv_obj_t* blueBtnm;
 
-pros::Task tabWatcher_task = (pros::task_t)NULL;
+pros::task_t tabWatcher_task = (pros::task_t)NULL;
 
 lv_res_t redBtnmAction(lv_obj_t* btnm, const char* txt) {
 	// printf("red button: %s released\n", txt);
@@ -130,7 +130,7 @@ void init(int hue, int default_auton, const char** autons) {
 	lv_obj_align(skillsBtn, NULL, LV_ALIGN_CENTER, 0, 0);
 
 	// start tab watcher
-	tabWatcher_task = pros::Task(tabWatcher);
+	tabWatcher_task = pros::task_t(tabWatcher);
 }
 
 void destroy() {

--- a/src/ARMS/selector.cpp
+++ b/src/ARMS/selector.cpp
@@ -11,6 +11,8 @@ lv_obj_t* tabview;
 lv_obj_t* redBtnm;
 lv_obj_t* blueBtnm;
 
+pros::Task tabWatcher_task = (pros::task_t)NULL;
+
 lv_res_t redBtnmAction(lv_obj_t* btnm, const char* txt) {
 	// printf("red button: %s released\n", txt);
 
@@ -128,11 +130,13 @@ void init(int hue, int default_auton, const char** autons) {
 	lv_obj_align(skillsBtn, NULL, LV_ALIGN_CENTER, 0, 0);
 
 	// start tab watcher
-	pros::Task tabWatcher_task(tabWatcher);
+	tabWatcher_task = pros::Task(tabWatcher);
 }
 
 void destroy() {
 	lv_obj_del(tabview);
+
+	tabWatcher_task = (pros::task_t)NULL;
 }
 
 } // namespace arms::selector

--- a/src/ARMS/selector.cpp
+++ b/src/ARMS/selector.cpp
@@ -131,4 +131,8 @@ void init(int hue, int default_auton, const char** autons) {
 	pros::Task tabWatcher_task(tabWatcher);
 }
 
+void destroy() {
+	lv_obj_del(tabview);
+}
+
 } // namespace arms::selector


### PR DESCRIPTION
This PR adds the ability to destroy the auton selector. This allows you to display a different screen for opcontrol or other reasons.