### PR TITLE
Fix project recompilation issue

### DIFF
--- a/include/ARMS/api.h
+++ b/include/ARMS/api.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include "ARMS/lib.h"
-
-// The config file needs to be last because the arms::init()
-// function inside of it depends on init() funciton of the subsystems
-#include "ARMS/config.h"
+#include "ARMS/chassis.h"
+#include "ARMS/flags.h"
+#include "ARMS/odom.h"
+#include "ARMS/pid.h"
+#include "ARMS/point.h"
+#include "ARMS/selector.h"

--- a/include/ARMS/config.h
+++ b/include/ARMS/config.h
@@ -1,7 +1,7 @@
 #ifndef _ARMS_CONFIG_H_
 #define _ARMS_CONFIG_H_
 
-#include "ARMS/lib.h"
+#include "ARMS/api.h"
 
 
 namespace arms {

--- a/include/ARMS/lib.h
+++ b/include/ARMS/lib.h
@@ -1,8 +1,0 @@
-#pragma once
-
-#include "ARMS/chassis.h"
-#include "ARMS/flags.h"
-#include "ARMS/odom.h"
-#include "ARMS/pid.h"
-#include "ARMS/point.h"
-#include "ARMS/selector.h"

--- a/include/main.h
+++ b/include/main.h
@@ -7,7 +7,6 @@
 #include "ARMS/api.h"
 #include "api.h"
 
-// subsystems
 using namespace pros;
 
 #ifdef __cplusplus

--- a/src/ARMS/chassis.cpp
+++ b/src/ARMS/chassis.cpp
@@ -1,4 +1,4 @@
-#include "ARMS/lib.h"
+#include "ARMS/api.h"
 #include "api.h"
 #include "pros/motors.h"
 

--- a/src/ARMS/odom.cpp
+++ b/src/ARMS/odom.cpp
@@ -1,4 +1,4 @@
-#include "ARMS/lib.h"
+#include "ARMS/api.h"
 #include "api.h"
 
 namespace arms::odom {

--- a/src/ARMS/pid.cpp
+++ b/src/ARMS/pid.cpp
@@ -1,4 +1,4 @@
-#include "ARMS/lib.h"
+#include "ARMS/api.h"
 #include "api.h"
 
 namespace arms::pid {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,5 @@
 #include "main.h"
+#include "ARMS/config.h"
 
 pros::Controller master(CONTROLLER_MASTER);
 


### PR DESCRIPTION
Config is no longer included in api.h. This should prevent total project recompilation every time the config is changed.